### PR TITLE
Added Anonymization API

### DIFF
--- a/bukkit/example-plugin/src/main/java/com/example/ExamplePlugin.java
+++ b/bukkit/example-plugin/src/main/java/com/example/ExamplePlugin.java
@@ -5,15 +5,26 @@ import dev.faststats.core.ErrorTracker;
 import dev.faststats.core.data.Metric;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
+import java.nio.file.AccessDeniedException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class ExamplePlugin extends JavaPlugin {
     // context-aware error tracker, automatically tracks errors in the same class loader
-    public static final ErrorTracker ERROR_TRACKER = ErrorTracker.contextAware();
+    public static final ErrorTracker ERROR_TRACKER = ErrorTracker.contextAware()
+            // Ignore specific errors and messages
+            .ignoreError(InvocationTargetException.class, "Expected .* but got .*") // Ignored an error with a message
+            .ignoreError(AccessDeniedException.class); // Ignored a specific error type
 
     // context-unaware error tracker, does not automatically track errors
-    public static final ErrorTracker CONTEXT_UNAWARE_ERROR_TRACKER = ErrorTracker.contextUnaware();
+    public static final ErrorTracker CONTEXT_UNAWARE_ERROR_TRACKER = ErrorTracker.contextUnaware()
+            // Anonymize error messages if required
+            .anonymize("^[\\w-.]+@([\\w-]+\\.)+[\\w-]{2,4}$", "[email hidden]") // Email addresses
+            .anonymize("Bearer [A-Za-z0-9._~+/=-]+", "Bearer [token hidden]") // Bearer tokens in error messages
+            .anonymize("AKIA[0-9A-Z]{16}", "[aws-key hidden]") // AWS access key IDs
+            .anonymize("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", "[uuid hidden]") // UUIDs (e.g. session/user IDs)
+            .anonymize("([?&](?:api_?key|token|secret)=)[^&\\s]+", "$1[redacted]"); // API keys in query strings
 
     private final AtomicInteger gameCount = new AtomicInteger();
 

--- a/core/src/main/java/dev/faststats/core/ErrorHelper.java
+++ b/core/src/main/java/dev/faststats/core/ErrorHelper.java
@@ -20,7 +20,7 @@ final class ErrorHelper {
     private static final int STACK_TRACE_LIMIT = Math.min(50, Integer.getInteger("faststats.stack-trace-limit", 15));
 
     public static JsonObject compile(final Throwable error, @Nullable final List<String> suppress, final boolean handled,
-                                     final Map<Pattern, String> customPatterns) {
+                                     final List<Map.Entry<Pattern, String>> customPatterns) {
         final var report = new JsonObject();
         final var message = getAnonymizedMessage(error, customPatterns);
 
@@ -50,7 +50,7 @@ final class ErrorHelper {
 
     private static void appendCauseChain(@Nullable Throwable cause, final List<String> parentStack,
                                          @Nullable final List<String> suppress, final JsonArray stacktrace,
-                                         final Map<Pattern, String> customPatterns) {
+                                         final List<Map.Entry<Pattern, String>> customPatterns) {
         final var toSuppress = new ArrayList<>(parentStack);
         if (suppress != null) toSuppress.addAll(suppress);
         final var visited = Collections.<Throwable>newSetFromMap(new IdentityHashMap<>());
@@ -193,13 +193,13 @@ final class ErrorHelper {
         return loader == current;
     }
 
-    private static @Nullable String getAnonymizedMessage(final Throwable error, final Map<Pattern, String> customPatterns) {
+    private static @Nullable String getAnonymizedMessage(final Throwable error, final List<Map.Entry<Pattern, String>> customPatterns) {
         final var message = error.getMessage();
         if (message == null) return null;
         var truncated = message.length() > MESSAGE_LENGTH
                 ? message.substring(0, MESSAGE_LENGTH) + "..."
                 : message;
-        for (final var entry : customPatterns.entrySet()) {
+        for (final var entry : customPatterns) {
             truncated = entry.getKey().matcher(truncated).replaceAll(entry.getValue());
         }
         return truncated;
@@ -228,7 +228,7 @@ final class ErrorHelper {
     }
 
     public static Pattern jdbcUrlPattern() {
-        return Pattern.compile("(jdbc:[^:]+://[^:]+:)[^@]+(@)");
+        return Pattern.compile("(jdbc:[^:]+://[^:]+:(?:\\d+:)?)[^@]+(@)");
     }
 
     public static Pattern userHomePathPattern() {
@@ -238,7 +238,8 @@ final class ErrorHelper {
     }
 
     public static Optional<Pattern> usernamePattern() {
-        return Optional.ofNullable(System.getProperty("user.home"))
+        return Optional.ofNullable(System.getProperty("user.name"))
+                .filter(s -> s.trim().length() > 2)
                 .map(Pattern::quote)
                 .map(Pattern::compile);
     }

--- a/core/src/main/java/dev/faststats/core/ErrorHelper.java
+++ b/core/src/main/java/dev/faststats/core/ErrorHelper.java
@@ -9,6 +9,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -17,9 +19,10 @@ final class ErrorHelper {
     private static final int STACK_TRACE_LENGTH = Math.min(500, Integer.getInteger("faststats.stack-trace-length", 300));
     private static final int STACK_TRACE_LIMIT = Math.min(50, Integer.getInteger("faststats.stack-trace-limit", 15));
 
-    public static JsonObject compile(final Throwable error, @Nullable final List<String> suppress, final boolean handled) {
+    public static JsonObject compile(final Throwable error, @Nullable final List<String> suppress, final boolean handled,
+                                     final Map<Pattern, String> customPatterns) {
         final var report = new JsonObject();
-        final var message = getAnonymizedMessage(error);
+        final var message = getAnonymizedMessage(error, customPatterns);
 
         final var stacktrace = new JsonArray();
         final var header = message != null
@@ -34,7 +37,7 @@ final class ErrorHelper {
         final var traces = Math.min(list.size(), STACK_TRACE_LIMIT);
 
         populateTraces(traces, list, elements, stacktrace);
-        appendCauseChain(error.getCause(), stack, suppress, stacktrace);
+        appendCauseChain(error.getCause(), stack, suppress, stacktrace, customPatterns);
 
         report.addProperty("error", error.getClass().getName());
         if (message != null) report.addProperty("message", message);
@@ -46,12 +49,13 @@ final class ErrorHelper {
     }
 
     private static void appendCauseChain(@Nullable Throwable cause, final List<String> parentStack,
-                                         @Nullable final List<String> suppress, final JsonArray stacktrace) {
+                                         @Nullable final List<String> suppress, final JsonArray stacktrace,
+                                         final Map<Pattern, String> customPatterns) {
         final var toSuppress = new ArrayList<>(parentStack);
         if (suppress != null) toSuppress.addAll(suppress);
         final var visited = Collections.<Throwable>newSetFromMap(new IdentityHashMap<>());
         while (cause != null && visited.add(cause)) {
-            final var causeMessage = getAnonymizedMessage(cause);
+            final var causeMessage = getAnonymizedMessage(cause, customPatterns);
             final var header = causeMessage != null
                     ? "Caused by: " + cause.getClass().getName() + ": " + causeMessage
                     : "Caused by: " + cause.getClass().getName();
@@ -68,7 +72,8 @@ final class ErrorHelper {
         }
     }
 
-    private static void populateTraces(final int traces, final List<String> list, final StackTraceElement[] elements, final JsonArray stacktrace) {
+    private static void populateTraces(final int traces, final List<String> list, final StackTraceElement[] elements,
+                                       final JsonArray stacktrace) {
         for (var i = 0; i < traces; i++) {
             final var string = list.get(i);
             if (string.length() <= STACK_TRACE_LENGTH) stacktrace.add("  at " + string);
@@ -188,40 +193,53 @@ final class ErrorHelper {
         return loader == current;
     }
 
-    private static final Pattern IPV4_PATTERN = Pattern.compile(
-            "\\b(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\b");
-    private static final Pattern IPV6_PATTERN = Pattern.compile(
-            "(?i)\\b([0-9a-f]{1,4}:){7}[0-9a-f]{1,4}\\b|" +                      // Full form
-                    "(?i)\\b([0-9a-f]{1,4}:){1,7}:\\b|" +                        // Trailing ::
-                    "(?i)\\b([0-9a-f]{1,4}:){1,6}:[0-9a-f]{1,4}\\b|" +           // :: in middle (1 group after)
-                    "(?i)\\b([0-9a-f]{1,4}:){1,5}(:[0-9a-f]{1,4}){1,2}\\b|" +    // :: in middle (2 groups after)
-                    "(?i)\\b([0-9a-f]{1,4}:){1,4}(:[0-9a-f]{1,4}){1,3}\\b|" +    // :: in middle (3 groups after)
-                    "(?i)\\b([0-9a-f]{1,4}:){1,3}(:[0-9a-f]{1,4}){1,4}\\b|" +    // :: in middle (4 groups after)
-                    "(?i)\\b([0-9a-f]{1,4}:){1,2}(:[0-9a-f]{1,4}){1,5}\\b|" +    // :: in middle (5 groups after)
-                    "(?i)\\b[0-9a-f]{1,4}:(:[0-9a-f]{1,4}){1,6}\\b|" +           // :: in middle (6 groups after)
-                    "(?i)\\b:(:[0-9a-f]{1,4}){1,7}\\b|" +                        // Leading ::
-                    "(?i)\\b::([0-9a-f]{1,4}:){0,5}[0-9a-f]{1,4}\\b|" +          // :: at start
-                    "(?i)\\b::\\b");                                             // Just ::
-    private static final Pattern USER_HOME_PATH_PATTERN = Pattern.compile(
-            "(/home/)[^/\\s]+" +                                                 // Linux: /home/username
-                    "|(/Users/)[^/\\s]+" +                                       // macOS: /Users/username
-                    "|((?i)[A-Z]:\\\\Users\\\\)[^\\\\\\s]+");                    // Windows: A-Z:\\Users\\username
-
-    private static String anonymize(String message) {
-        message = IPV4_PATTERN.matcher(message).replaceAll("[IP hidden]");
-        message = IPV6_PATTERN.matcher(message).replaceAll("[IP hidden]");
-        message = USER_HOME_PATH_PATTERN.matcher(message).replaceAll("$1$2$3[username hidden]");
-        final var username = System.getProperty("user.name");
-        if (username != null) message = message.replace(username, "[username hidden]");
-        return message;
-    }
-
-    private static @Nullable String getAnonymizedMessage(final Throwable error) {
+    private static @Nullable String getAnonymizedMessage(final Throwable error, final Map<Pattern, String> customPatterns) {
         final var message = error.getMessage();
         if (message == null) return null;
-        final var truncated = message.length() > MESSAGE_LENGTH
+        var truncated = message.length() > MESSAGE_LENGTH
                 ? message.substring(0, MESSAGE_LENGTH) + "..."
                 : message;
-        return anonymize(truncated);
+        for (final var entry : customPatterns.entrySet()) {
+            truncated = entry.getKey().matcher(truncated).replaceAll(entry.getValue());
+        }
+        return truncated;
+    }
+
+    public static Pattern discordWebhookPattern() {
+        return Pattern.compile("(https://discord\\.com/api/webhooks/\\d+/)[\\w-]+");
+    }
+
+    public static Pattern ipv4Pattern() {
+        return Pattern.compile("\\b(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\b");
+    }
+
+    public static Pattern ipv6Pattern() {
+        return Pattern.compile("(?i)\\b([0-9a-f]{1,4}:){7}[0-9a-f]{1,4}\\b|" + // Full form
+                "(?i)\\b([0-9a-f]{1,4}:){1,7}:\\b|" +                          // Trailing ::
+                "(?i)\\b([0-9a-f]{1,4}:){1,6}:[0-9a-f]{1,4}\\b|" +             // :: in middle (1 group after)
+                "(?i)\\b([0-9a-f]{1,4}:){1,5}(:[0-9a-f]{1,4}){1,2}\\b|" +      // :: in middle (2 groups after)
+                "(?i)\\b([0-9a-f]{1,4}:){1,4}(:[0-9a-f]{1,4}){1,3}\\b|" +      // :: in middle (3 groups after)
+                "(?i)\\b([0-9a-f]{1,4}:){1,3}(:[0-9a-f]{1,4}){1,4}\\b|" +      // :: in middle (4 groups after)
+                "(?i)\\b([0-9a-f]{1,4}:){1,2}(:[0-9a-f]{1,4}){1,5}\\b|" +      // :: in middle (5 groups after)
+                "(?i)\\b[0-9a-f]{1,4}:(:[0-9a-f]{1,4}){1,6}\\b|" +             // :: in middle (6 groups after)
+                "(?i)\\b:(:[0-9a-f]{1,4}){1,7}\\b|" +                          // Leading ::
+                "(?i)\\b::([0-9a-f]{1,4}:){0,5}[0-9a-f]{1,4}\\b|" +            // :: at start
+                "(?i)\\b::\\b");                                               // Just ::
+    }
+
+    public static Pattern jdbcUrlPattern() {
+        return Pattern.compile("(jdbc:[^:]+://[^:]+:)[^@]+(@)");
+    }
+
+    public static Pattern userHomePathPattern() {
+        return Pattern.compile("(/home/)[^/\\s]+" +       // Linux: /home/username
+                "|(/Users/)[^/\\s]+" +                    // macOS: /Users/username
+                "|((?i)[A-Z]:\\\\Users\\\\)[^\\\\\\s]+"); // Windows: A-Z:\\Users\\username
+    }
+
+    public static Optional<Pattern> usernamePattern() {
+        return Optional.ofNullable(System.getProperty("user.home"))
+                .map(Pattern::quote)
+                .map(Pattern::compile);
     }
 }

--- a/core/src/main/java/dev/faststats/core/ErrorTracker.java
+++ b/core/src/main/java/dev/faststats/core/ErrorTracker.java
@@ -178,6 +178,36 @@ public sealed interface ErrorTracker permits SimpleErrorTracker {
     }
 
     /**
+     * Adds an anonymization pattern that replaces matched text in error messages.
+     * <pre>{@code
+     * tracker.anonymize(Pattern.compile("token=[^&]+"), "token=[redacted]");
+     * }</pre>
+     *
+     * @param pattern     the regex pattern to match
+     * @param replacement the replacement string
+     * @return the error tracker
+     * @see java.util.regex.Matcher#replaceAll(String)
+     * @since 0.22.0
+     */
+    @Contract(value = "_, _ -> this", mutates = "this")
+    ErrorTracker anonymize(Pattern pattern, String replacement);
+
+    /**
+     * Adds an anonymization pattern that replaces matched text in error messages.
+     *
+     * @param pattern     the regex pattern string to match
+     * @param replacement the replacement string
+     * @return the error tracker
+     * @see #anonymize(Pattern, String)
+     * @see java.util.regex.Matcher#replaceAll(String)
+     * @since 0.22.0
+     */
+    @Contract(value = "_, _ -> this", mutates = "this")
+    default ErrorTracker anonymize(@RegExp final String pattern, final String replacement) {
+        return anonymize(Pattern.compile(pattern), replacement);
+    }
+
+    /**
      * Attaches an error context to the tracker.
      * <p>
      * If the class loader is {@code null}, the tracker will track all errors.

--- a/core/src/main/java/dev/faststats/core/ErrorTracker.java
+++ b/core/src/main/java/dev/faststats/core/ErrorTracker.java
@@ -106,10 +106,10 @@ public sealed interface ErrorTracker permits SimpleErrorTracker {
      *
      * @param type the error type
      * @return the error tracker
-     * @since 0.21.0
+     * @since 0.22.0
      */
     @Contract(value = "_ -> this", mutates = "this")
-    ErrorTracker ignoreErrorType(Class<? extends Throwable> type);
+    ErrorTracker ignoreError(Class<? extends Throwable> type);
 
     /**
      * Adds a pattern that will be matched against all error messages.

--- a/core/src/main/java/dev/faststats/core/SimpleErrorTracker.java
+++ b/core/src/main/java/dev/faststats/core/SimpleErrorTracker.java
@@ -23,9 +23,20 @@ final class SimpleErrorTracker implements ErrorTracker {
     private final Map<Class<? extends Throwable>, Set<Pattern>> ignoredTypedPatterns = new ConcurrentHashMap<>();
     private final Set<Class<? extends Throwable>> ignoredTypes = new CopyOnWriteArraySet<>();
     private final Set<Pattern> ignoredPatterns = new CopyOnWriteArraySet<>();
+    private final Map<Pattern, String> anonymizationEntries = new ConcurrentHashMap<>(Map.of(
+            ErrorHelper.discordWebhookPattern(), "$1[token hidden]",
+            ErrorHelper.ipv4Pattern(), "[IP hidden]",
+            ErrorHelper.ipv6Pattern(), "[IP hidden]",
+            ErrorHelper.jdbcUrlPattern(), "$1[password hidden]$2",
+            ErrorHelper.userHomePathPattern(), "$1$2$3[username hidden]"
+    ));
 
     private volatile @Nullable BiConsumer<@Nullable ClassLoader, Throwable> errorEvent = null;
     private volatile @Nullable UncaughtExceptionHandler originalHandler = null;
+
+    public SimpleErrorTracker() {
+        ErrorHelper.usernamePattern().ifPresent(pattern -> anonymizationEntries.put(pattern, "[username hidden]"));
+    }
 
     @Override
     public void trackError(final String message) {
@@ -46,7 +57,7 @@ final class SimpleErrorTracker implements ErrorTracker {
     public void trackError(final Throwable error, final boolean handled) {
         try {
             if (isIgnored(error, Collections.newSetFromMap(new IdentityHashMap<>()))) return;
-            final var compiled = ErrorHelper.compile(error, null, handled);
+            final var compiled = ErrorHelper.compile(error, null, handled, anonymizationEntries);
             final var hashed = MurmurHash3.hash(compiled);
             if (collected.compute(hashed, (k, v) -> {
                 return v == null ? 1 : v + 1;
@@ -86,6 +97,12 @@ final class SimpleErrorTracker implements ErrorTracker {
     @Override
     public ErrorTracker ignoreError(final Class<? extends Throwable> type, final Pattern pattern) {
         ignoredTypedPatterns.computeIfAbsent(type, k -> new CopyOnWriteArraySet<>()).add(pattern);
+        return this;
+    }
+
+    @Override
+    public ErrorTracker anonymize(final Pattern pattern, final String replacement) {
+        anonymizationEntries.put(pattern, replacement);
         return this;
     }
 

--- a/core/src/main/java/dev/faststats/core/SimpleErrorTracker.java
+++ b/core/src/main/java/dev/faststats/core/SimpleErrorTracker.java
@@ -7,10 +7,12 @@ import org.jspecify.annotations.Nullable;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.Collections;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
@@ -23,19 +25,19 @@ final class SimpleErrorTracker implements ErrorTracker {
     private final Map<Class<? extends Throwable>, Set<Pattern>> ignoredTypedPatterns = new ConcurrentHashMap<>();
     private final Set<Class<? extends Throwable>> ignoredTypes = new CopyOnWriteArraySet<>();
     private final Set<Pattern> ignoredPatterns = new CopyOnWriteArraySet<>();
-    private final Map<Pattern, String> anonymizationEntries = new ConcurrentHashMap<>(Map.of(
-            ErrorHelper.discordWebhookPattern(), "$1[token hidden]",
-            ErrorHelper.ipv4Pattern(), "[IP hidden]",
-            ErrorHelper.ipv6Pattern(), "[IP hidden]",
-            ErrorHelper.jdbcUrlPattern(), "$1[password hidden]$2",
-            ErrorHelper.userHomePathPattern(), "$1$2$3[username hidden]"
+    private final List<Map.Entry<Pattern, String>> anonymizationEntries = new CopyOnWriteArrayList<>(List.of(
+            Map.entry(ErrorHelper.ipv4Pattern(), "[IP hidden]"),
+            Map.entry(ErrorHelper.ipv6Pattern(), "[IP hidden]"),
+            Map.entry(ErrorHelper.userHomePathPattern(), "$1$2$3[username hidden]"),
+            Map.entry(ErrorHelper.discordWebhookPattern(), "$1[token hidden]"),
+            Map.entry(ErrorHelper.jdbcUrlPattern(), "$1[password hidden]$2")
     ));
 
     private volatile @Nullable BiConsumer<@Nullable ClassLoader, Throwable> errorEvent = null;
     private volatile @Nullable UncaughtExceptionHandler originalHandler = null;
 
     public SimpleErrorTracker() {
-        ErrorHelper.usernamePattern().ifPresent(pattern -> anonymizationEntries.put(pattern, "[username hidden]"));
+        ErrorHelper.usernamePattern().ifPresent(pattern -> anonymizationEntries.add(Map.entry(pattern, "[username hidden]")));
     }
 
     @Override
@@ -102,7 +104,7 @@ final class SimpleErrorTracker implements ErrorTracker {
 
     @Override
     public ErrorTracker anonymize(final Pattern pattern, final String replacement) {
-        anonymizationEntries.put(pattern, replacement);
+        anonymizationEntries.add(Map.entry(pattern, replacement));
         return this;
     }
 

--- a/core/src/main/java/dev/faststats/core/SimpleErrorTracker.java
+++ b/core/src/main/java/dev/faststats/core/SimpleErrorTracker.java
@@ -72,7 +72,7 @@ final class SimpleErrorTracker implements ErrorTracker {
     }
 
     @Override
-    public ErrorTracker ignoreErrorType(final Class<? extends Throwable> type) {
+    public ErrorTracker ignoreError(final Class<? extends Throwable> type) {
         ignoredTypes.add(type);
         return this;
     }

--- a/core/src/test/java/dev/faststats/AnonymizationTest.java
+++ b/core/src/test/java/dev/faststats/AnonymizationTest.java
@@ -1,0 +1,206 @@
+package dev.faststats;
+
+import com.google.gson.JsonObject;
+import dev.faststats.core.ErrorTracker;
+import org.jspecify.annotations.NullMarked;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@NullMarked
+public final class AnonymizationTest {
+    private static MockMetrics createMetrics(final ErrorTracker tracker) {
+        return new MockMetrics(UUID.randomUUID(), "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", tracker, false);
+    }
+
+    private static JsonObject getError(final MockMetrics metrics) {
+        final var data = metrics.createData();
+        return data.getAsJsonArray("errors").get(0).getAsJsonObject();
+    }
+
+    private static String getErrorMessage(final MockMetrics metrics) {
+        return getError(metrics).get("message").getAsString();
+    }
+
+    @Test
+    public void ipv4Anonymization() {
+        final var tracker = ErrorTracker.contextUnaware();
+        final var metrics = createMetrics(tracker);
+        tracker.trackError("Connection refused at 192.168.1.100");
+        assertEquals("Connection refused at [IP hidden]", getErrorMessage(metrics));
+    }
+
+    @Test
+    public void ipv6Anonymization() {
+        final var tracker = ErrorTracker.contextUnaware();
+        final var metrics = createMetrics(tracker);
+        tracker.trackError("Failed to connect to f833:be65:65da:975b:4896:88f7:6964:44c0");
+        assertEquals("Failed to connect to [IP hidden]", getErrorMessage(metrics));
+    }
+
+    @Test
+    public void userHomePathAnonymization() {
+        final var tracker = ErrorTracker.contextUnaware();
+        final var metrics = createMetrics(tracker);
+        final var username = System.getProperty("user.name", "user");
+        tracker.trackError("File not found: /home/" + username + "/config.yml");
+        assertEquals("File not found: /home/[username hidden]/config.yml", getErrorMessage(metrics));
+    }
+
+    @Test
+    public void windowsUserPathAnonymization() {
+        final var tracker = ErrorTracker.contextUnaware();
+        final var metrics = createMetrics(tracker);
+        final var username = System.getProperty("user.name", "user");
+        tracker.trackError("File not found: C:\\Users\\" + username + "\\config.yml");
+        assertEquals("File not found: C:\\Users\\[username hidden]\\config.yml", getErrorMessage(metrics));
+    }
+
+    @Test
+    public void macUserPathAnonymization() {
+        final var tracker = ErrorTracker.contextUnaware();
+        final var metrics = createMetrics(tracker);
+        final var username = System.getProperty("user.name", "user");
+        tracker.trackError("File not found: /Users/" + username + "/config.yml");
+        assertEquals("File not found: /Users/[username hidden]/config.yml", getErrorMessage(metrics));
+    }
+
+    @Test
+    public void discordWebhookAnonymization() {
+        final var tracker = ErrorTracker.contextUnaware();
+        final var metrics = createMetrics(tracker);
+        tracker.trackError("Webhook failed: https://discord.com/api/webhooks/1234567890987654321/aAaAaAaa0AAaAAaaaAAAAa_0AAAAAAAaaaAaaAaaAAAA0aA00AAA0AAA0aAAaA0a0a0A");
+        assertEquals("Webhook failed: https://discord.com/api/webhooks/1234567890987654321/[token hidden]", getErrorMessage(metrics));
+    }
+
+    @Test
+    public void jdbcUrlAnonymization() {
+        final var tracker = ErrorTracker.contextUnaware();
+        final var metrics = createMetrics(tracker);
+        tracker.trackError("Failed: jdbc:mysql://localhost:3306:secretpass@mydb");
+        assertEquals("Failed: jdbc:mysql://localhost:3306:[password hidden]@mydb", getErrorMessage(metrics));
+    }
+
+    @Test
+    public void jdbcUrlNoPortAnonymization() {
+        final var tracker = ErrorTracker.contextUnaware();
+        final var metrics = createMetrics(tracker);
+        tracker.trackError("Failed: jdbc:mysql://mydb.com:secretpass@mydb");
+        assertEquals("Failed: jdbc:mysql://mydb.com:[password hidden]@mydb", getErrorMessage(metrics));
+    }
+
+    @Test
+    public void jdbcUrlIpAnonymization() {
+        final var tracker = ErrorTracker.contextUnaware();
+        final var metrics = createMetrics(tracker);
+        tracker.trackError("Failed: jdbc:mysql://127.0.0.1:3306:secretpass@mydb");
+        assertEquals("Failed: jdbc:mysql://[IP hidden]:3306:[password hidden]@mydb", getErrorMessage(metrics));
+    }
+
+    @Test
+    public void customPatternAnonymizesMessage() {
+        final var tracker = ErrorTracker.contextUnaware()
+                .anonymize("token=[^&]+", "token=[redacted]");
+        final var metrics = createMetrics(tracker);
+        tracker.trackError("Request failed with token=abc123secret&user=test");
+        assertEquals("Request failed with token=[redacted]&user=test", getErrorMessage(metrics));
+    }
+
+    @Test
+    public void customPatternWithCompiledPattern() {
+        final var tracker = ErrorTracker.contextUnaware()
+                .anonymize(Pattern.compile("Bearer [A-Za-z0-9._~+/=-]+"), "Bearer [redacted]");
+        final var metrics = createMetrics(tracker);
+        tracker.trackError("Auth failed: Bearer eyJhbGciOiJIUzI1NiJ9.payload.signature");
+        assertEquals("Auth failed: Bearer [redacted]", getErrorMessage(metrics));
+    }
+
+    @Test
+    public void customPatternWithCaptureGroupReplacement() {
+        final var tracker = ErrorTracker.contextUnaware()
+                .anonymize("(api_key=)[^&\\s]+", "$1[redacted]");
+        final var metrics = createMetrics(tracker);
+        tracker.trackError("GET /data?api_key=sk_live_12345&format=json failed");
+        assertEquals("GET /data?api_key=[redacted]&format=json failed", getErrorMessage(metrics));
+    }
+
+    @Test
+    public void multipleCustomPatterns() {
+        final var tracker = ErrorTracker.contextUnaware()
+                .anonymize("Bearer [A-Za-z0-9._~+/=-]+", "Bearer [redacted]")
+                .anonymize("[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}", "[email hidden]");
+        final var metrics = createMetrics(tracker);
+        tracker.trackError("Auth failed for user@example.com with Bearer eyJ0eXAi");
+        assertEquals("Auth failed for [email hidden] with Bearer [redacted]", getErrorMessage(metrics));
+    }
+
+    @Test
+    public void customPatternChaining() {
+        final var tracker = ErrorTracker.contextUnaware()
+                .anonymize("secret-[a-z]+", "[secret hidden]")
+                .anonymize("AKIA[0-9A-Z]{16}", "[aws-key hidden]");
+        final var metrics = createMetrics(tracker);
+        tracker.trackError("Credentials: secret-abcdef / AKIA1234567890ABCDEF");
+        assertEquals("Credentials: [secret hidden] / [aws-key hidden]", getErrorMessage(metrics));
+    }
+
+    @Test
+    public void customPatternAppliedToCauseChain() {
+        final var tracker = ErrorTracker.contextUnaware()
+                .anonymize("ssn=\\d{3}-\\d{2}-\\d{4}", "ssn=[redacted]");
+        final var metrics = createMetrics(tracker);
+        final var cause = new IllegalArgumentException("Validation failed for ssn=123-45-6789");
+        tracker.trackError(new RuntimeException("Processing error", cause));
+        final var error = getError(metrics);
+        final var stack = error.getAsJsonArray("stack");
+        var causeAnonymized = false;
+        for (final var element : stack) {
+            final var line = element.getAsString();
+            assertFalse(line.contains("123-45-6789"));
+            if (line.startsWith("Caused by:") && line.contains("ssn=[redacted]")) causeAnonymized = true;
+        }
+        assertTrue(causeAnonymized);
+    }
+
+    @Test
+    public void nullMessageNotAffected() {
+        final var tracker = ErrorTracker.contextUnaware()
+                .anonymize("anything", "[redacted]");
+        final var metrics = createMetrics(tracker);
+        tracker.trackError(new RuntimeException((String) null));
+        assertFalse(getError(metrics).has("message"));
+    }
+
+    @Test
+    public void customAndBuiltInPatternsCombined() {
+        final var tracker = ErrorTracker.contextUnaware()
+                .anonymize("session=[a-f0-9]+", "session=[redacted]");
+        final var metrics = createMetrics(tracker);
+        final var username = System.getProperty("user.name", "user");
+        tracker.trackError("Error for 192.168.1.1 with session=deadbeef01 at /home/" + username + "/app");
+        assertEquals("Error for [IP hidden] with session=[redacted] at /home/[username hidden]/app", getErrorMessage(metrics));
+    }
+
+    @Test
+    public void emptyReplacementRemovesMatch() {
+        final var tracker = ErrorTracker.contextUnaware()
+                .anonymize("\\(internal ref: [^)]+\\)", "");
+        final var metrics = createMetrics(tracker);
+        tracker.trackError("Request failed (internal ref: REF-98765)");
+        assertEquals("Request failed ", getErrorMessage(metrics));
+    }
+
+    @Test
+    public void patternDoesNotMatchLeavesMessageUnchanged() {
+        final var tracker = ErrorTracker.contextUnaware()
+                .anonymize("SECRET_[A-Z]+", "[redacted]");
+        final var metrics = createMetrics(tracker);
+        tracker.trackError("just a normal error");
+        assertEquals("just a normal error", getErrorMessage(metrics));
+    }
+}

--- a/core/src/test/java/dev/faststats/MockMetrics.java
+++ b/core/src/test/java/dev/faststats/MockMetrics.java
@@ -12,7 +12,7 @@ import java.util.Set;
 import java.util.UUID;
 
 @NullMarked
-public class MockMetrics extends SimpleMetrics {
+public final class MockMetrics extends SimpleMetrics {
     public MockMetrics(final UUID serverId, @Token final String token, @Nullable final ErrorTracker tracker, final boolean debug) {
         super(new Config(serverId, true, debug, true, true, false, false), Set.of(), token, tracker, null, URI.create("http://localhost:5000/v1/collect"), debug);
     }


### PR DESCRIPTION
- Renamed `ErrorTracker#ignoreErrorType` to `#ignoreError` for consistency
- Added anonymization API to replace sensitive texts in error messages with redacted versions
- Added default anonymization for Discord Webhook URLs, and JDBC connection URLs
- Added more examples
- Added anonymization tests