### PR TITLE
Add user agent provider API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,7 +92,7 @@ subprojects {
 
     tasks.javadoc {
         val options = options as StandardJavadocDocletOptions
-        options.tags("apiNote:a:API Note:", "implSpec:a:Implementation Requirements:")
+        options.tags("apiNote:a:API Note:", "implSpec:a:Implementation Requirements:", "implNote:a:Implementation Note:")
         project.findProperty("moduleName")?.let { moduleName ->
             options.addStringOption("-add-reads", "$moduleName=ALL-UNNAMED")
         }

--- a/core/src/main/java/dev/faststats/SdkInfo.java
+++ b/core/src/main/java/dev/faststats/SdkInfo.java
@@ -1,5 +1,7 @@
 package dev.faststats;
 
+import org.jetbrains.annotations.Contract;
+
 import java.util.Optional;
 
 /**
@@ -38,6 +40,20 @@ public sealed interface SdkInfo permits SimpleSdkInfo {
 
     /**
      * Get the user agent sent with FastStats HTTP requests.
+     *
+     * @return the HTTP user agent
+     * @since 0.24.0
+     */
+    String getUserAgent();
+
+    /**
+     * Provides the HTTP user agent for the default {@link SdkInfo}
+     * implementation.
+     * <p>
+     * This service-provider hook is intended for SDKs that depend on
+     * FastStats core and need to identify their own distribution in outgoing
+     * requests. Implementations are discovered with {@link java.util.ServiceLoader};
+     * custom SDKs should provide one to override the core default user agent.
      * <p>
      * The user agent should include enough information to identify the client
      * implementation, including the vendor name, SDK name, and SDK version.
@@ -45,8 +61,19 @@ public sealed interface SdkInfo permits SimpleSdkInfo {
      * repository URL, Discord server, or website, so FastStats can reach the
      * implementation owner in case of abuse or operational problems.
      *
-     * @return the HTTP user agent
-     * @since 0.24.0
+     * @since 0.26.0
      */
-    String getUserAgent();
+    interface UserAgentProvider {
+        /**
+         * Get the user agent for the supplied SDK information.
+         * <p>
+         *
+         * @param sdkInfo the SDK information to build the user agent from
+         * @return the HTTP user agent
+         * @implNote Calling {@link SdkInfo#getUserAgent()} on the supplied SDK information has undefined behavior.
+         * @since 0.26.0
+         */
+        @Contract(pure = true)
+        String getUserAgent(SdkInfo sdkInfo);
+    }
 }

--- a/core/src/main/java/dev/faststats/SdkInfo.java
+++ b/core/src/main/java/dev/faststats/SdkInfo.java
@@ -66,7 +66,6 @@ public sealed interface SdkInfo permits SimpleSdkInfo {
     interface UserAgentProvider {
         /**
          * Get the user agent for the supplied SDK information.
-         * <p>
          *
          * @param sdkInfo the SDK information to build the user agent from
          * @return the HTTP user agent

--- a/core/src/main/java/dev/faststats/SimpleSdkInfo.java
+++ b/core/src/main/java/dev/faststats/SimpleSdkInfo.java
@@ -3,10 +3,16 @@ package dev.faststats;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Optional;
+import java.util.ServiceLoader;
 
 final class SimpleSdkInfo implements SdkInfo {
+    private static final UserAgentProvider userAgentProvider = ServiceLoader.load(UserAgentProvider.class)
+            .findFirst()
+            .orElseGet(SimpleSdkInfo.SimpleUserAgentProvider::new);
+
     private final @Nullable String buildId;
     private final String name;
+    private final String userAgent;
     private final String version;
 
     SimpleSdkInfo(final String name, final String version, @Nullable final String buildId) throws IllegalArgumentException {
@@ -15,6 +21,7 @@ final class SimpleSdkInfo implements SdkInfo {
         this.name = name;
         this.version = version;
         this.buildId = buildId;
+        this.userAgent = userAgentProvider.getUserAgent(this);
     }
 
     @Override
@@ -34,6 +41,13 @@ final class SimpleSdkInfo implements SdkInfo {
 
     @Override
     public String getUserAgent() {
-        return "FastStats Metrics " + name + "/" + version;
+        return userAgent;
+    }
+
+    static final class SimpleUserAgentProvider implements UserAgentProvider {
+        @Override
+        public String getUserAgent(final SdkInfo sdkInfo) {
+            return "FastStats Metrics " + sdkInfo.getName() + "/" + sdkInfo.getVersion();
+        }
     }
 }

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -13,5 +13,6 @@ module dev.faststats {
     requires static org.jetbrains.annotations;
     requires static org.jspecify;
 
+    uses dev.faststats.SdkInfo.UserAgentProvider;
     uses dev.faststats.internal.LoggerFactory;
 }

--- a/core/src/test/java/dev/faststats/UserAgentProviderTest.java
+++ b/core/src/test/java/dev/faststats/UserAgentProviderTest.java
@@ -1,0 +1,25 @@
+package dev.faststats;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public final class UserAgentProviderTest {
+    @Test
+    public void customUserAgentIsRetrievedFromSdkInfo() {
+        final var context = new MockContext.Factory()
+                .metrics(Metrics.Factory::create)
+                .create();
+
+        assertEquals(CustomUserAgentProvider.USER_AGENT, context.getSdkInfo().getUserAgent());
+    }
+
+    public static final class CustomUserAgentProvider implements SdkInfo.UserAgentProvider {
+        static final String USER_AGENT = "Example Vendor Example SDK/1.2.3 https://example.com/support";
+    
+        @Override
+        public String getUserAgent(final SdkInfo sdkInfo) {
+            return USER_AGENT;
+        }
+    }
+}

--- a/core/src/test/resources/META-INF/services/dev.faststats.SdkInfo$UserAgentProvider
+++ b/core/src/test/resources/META-INF/services/dev.faststats.SdkInfo$UserAgentProvider
@@ -1,0 +1,1 @@
+dev.faststats.UserAgentProviderTest$CustomUserAgentProvider

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=0.25.2
+version=0.26.0
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
This PR adds a UserAgentProvider interface that custom implementations should override to provide a custom user agent
Implementations are discovered with java's ServiceLoader